### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openroad/ubuntu22.04-dev:latest
+FROM openroad/ubuntu22.04-dev:0990b2
 
 RUN apt update && \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
@maliberty 
When we push the images for use in the CI, we do not update the `latest` tag. Updating the `latest` tag for a PR might not be a good idea as it would be overwritten on every push to every PR; updating on master is not the solution as well since it would require you to merge a PR without the clang review test. I will think of a better solution, but hard-coding here the image name to the one generated by your sta update PR should be enough.