### PR TITLE
Updates from upstream/master and fix PullRequest.get_pr_comments bug

### DIFF
--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -143,7 +143,7 @@ def get_auth_from_arguments(args: argparse.Namespace) -> Auth:
         return Auth.AppAuth(args.app_id, private_key).get_installation_auth(
             args.installation_id
         )
-    elif (
+    if (
         args.app_id
         or args.private_key
         or args.private_key_file_path
@@ -427,27 +427,24 @@ def get_diagnostic_file_path(clang_tidy_diagnostic, build_dir):
         file_path = clang_tidy_diagnostic["DiagnosticMessage"]["FilePath"]
         if file_path == "":
             return ""
-        elif os.path.isabs(file_path):
+        if os.path.isabs(file_path):
             return os.path.normpath(os.path.abspath(file_path))
-        elif "BuildDirectory" in clang_tidy_diagnostic:
+        if "BuildDirectory" in clang_tidy_diagnostic:
             return os.path.normpath(
                 os.path.abspath(
                     os.path.join(clang_tidy_diagnostic["BuildDirectory"], file_path)
                 )
             )
-        else:
-            return os.path.normpath(os.path.abspath(file_path))
+        return os.path.normpath(os.path.abspath(file_path))
 
     # Pre-clang-tidy-9 format
-    elif "FilePath" in clang_tidy_diagnostic:
+    if "FilePath" in clang_tidy_diagnostic:
         file_path = clang_tidy_diagnostic["FilePath"]
         if file_path == "":
             return ""
-        else:
-            return os.path.normpath(os.path.abspath(os.path.join(build_dir, file_path)))
+        return os.path.normpath(os.path.abspath(os.path.join(build_dir, file_path)))
 
-    else:
-        return ""
+    return ""
 
 
 def find_line_number_from_offset(offset_lookup, filename, offset):

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -1224,7 +1224,7 @@ def decorate_check_names(comment: str) -> str:
     url = f"https://clang.llvm.org/{version}/clang-tidy/checks"
     regex = r"(\[((?:clang-analyzer)|(?:(?!clang)[\w]+))-([\.\w-]+)\]$)"
     subst = f"[\\g<1>({url}/\\g<2>/\\g<3>.html)]"
-    return re.sub(regex, subst, comment, 1, re.MULTILINE)
+    return re.sub(regex, subst, comment, count=1, flags=re.MULTILINE)
 
 
 def decorate_comment(comment: PRReviewComment) -> PRReviewComment:

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -266,7 +266,7 @@ def merge_replacement_files(tmpdir: Path, mergefile: Path):
             yaml.safe_dump(output, out)
 
 
-def load_clang_tidy_warnings(fixes_file) -> Dict:
+def load_clang_tidy_warnings(fixes_file: Path) -> Dict:
     """Read clang-tidy warnings from fixes_file. Can be produced by build_clang_tidy_warnings"""
     try:
         with fixes_file.open() as f:
@@ -955,9 +955,7 @@ def create_review(
     files = filter_files(diff, include, exclude)
 
     if files == []:
-        with message_group("No files to check!"), Path(REVIEW_FILE).open(
-            "w"
-        ) as review_file:
+        with message_group("No files to check!"), REVIEW_FILE.open("w") as review_file:
             json.dump(
                 {
                     "body": "clang-tidy found no files to check",
@@ -972,7 +970,7 @@ def create_review(
 
     line_ranges = get_line_ranges(diff, files)
     if line_ranges == "[]":
-        with message_group("No lines added in this PR!"), Path(REVIEW_FILE).open(
+        with message_group("No lines added in this PR!"), REVIEW_FILE.open(
             "w"
         ) as review_file:
             json.dump(
@@ -1071,7 +1069,7 @@ def create_review(
         review = create_review_file(
             clang_tidy_warnings, diff_lookup, offset_lookup, build_dir
         )
-        with Path(REVIEW_FILE).open("w") as review_file:
+        with REVIEW_FILE.open("w") as review_file:
             json.dump(review, review_file)
 
         return review
@@ -1125,11 +1123,11 @@ def download_artifacts(pull: PullRequest, workflow_id: int):
 def load_metadata() -> Optional[Metadata]:
     """Load metadata from the METADATA_FILE path"""
 
-    if not pathlib.Path(METADATA_FILE).exists():
+    if not METADATA_FILE.exists():
         print(f"WARNING: Could not find metadata file ('{METADATA_FILE}')", flush=True)
         return None
 
-    with Path(METADATA_FILE).open() as metadata_file:
+    with METADATA_FILE.open() as metadata_file:
         return json.load(metadata_file)
 
 
@@ -1138,7 +1136,7 @@ def save_metadata(pr_number: int) -> None:
 
     metadata: Metadata = {"pr_number": pr_number}
 
-    with Path(METADATA_FILE).open("w") as metadata_file:
+    with METADATA_FILE.open("w") as metadata_file:
         json.dump(metadata, metadata_file)
 
 
@@ -1156,7 +1154,7 @@ def load_review(review_file: pathlib.Path) -> Optional[PRReview]:
 
 def load_and_merge_profiling() -> Dict:
     result = {}
-    for profile_file in Path(PROFILE_DIR).glob("*.json"):
+    for profile_file in PROFILE_DIR.glob("*.json"):
         profile_dict = json.load(profile_file.open())
         filename = profile_dict["file"]
         current_profile = result.get(filename, {})

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -139,7 +139,7 @@ def get_auth_from_arguments(args: argparse.Namespace) -> Auth:
         elif args.private_key_base64:
             private_key = base64.b64decode(args.private_key_base64).decode("ascii")
         else:
-            private_key = open(args.private_key_file_path).read()
+            private_key = pathlib.Path(args.private_key_file_path).read_text()
         return Auth.AppAuth(args.app_id, private_key).get_installation_auth(
             args.installation_id
         )

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -1111,11 +1111,13 @@ def download_artifacts(pull: PullRequest, workflow_id: int):
 
     metadata = (
         json.loads(data.read(str(METADATA_FILE)))
-        if METADATA_FILE in filenames
+        if str(METADATA_FILE) in filenames
         else None
     )
     review = (
-        json.loads(data.read(str(REVIEW_FILE))) if REVIEW_FILE in filenames else None
+        json.loads(data.read(str(REVIEW_FILE)))
+        if str(REVIEW_FILE) in filenames
+        else None
     )
     return metadata, review
 

--- a/post/clang_tidy_review/clang_tidy_review/__init__.py
+++ b/post/clang_tidy_review/clang_tidy_review/__init__.py
@@ -929,32 +929,34 @@ def create_review(
     files = filter_files(diff, include, exclude)
 
     if files == []:
-        with message_group("No files to check!"):
-            with Path(REVIEW_FILE).open("w") as review_file:
-                json.dump(
-                    {
-                        "body": "clang-tidy found no files to check",
-                        "event": "COMMENT",
-                        "comments": [],
-                    },
-                    review_file,
-                )
+        with message_group("No files to check!"), Path(REVIEW_FILE).open(
+            "w"
+        ) as review_file:
+            json.dump(
+                {
+                    "body": "clang-tidy found no files to check",
+                    "event": "COMMENT",
+                    "comments": [],
+                },
+                review_file,
+            )
         return None
 
     print(f"Checking these files: {files}", flush=True)
 
     line_ranges = get_line_ranges(diff, files)
     if line_ranges == "[]":
-        with message_group("No lines added in this PR!"):
-            with Path(REVIEW_FILE).open("w") as review_file:
-                json.dump(
-                    {
-                        "body": "clang-tidy found no lines added",
-                        "event": "COMMENT",
-                        "comments": [],
-                    },
-                    review_file,
-                )
+        with message_group("No lines added in this PR!"), Path(REVIEW_FILE).open(
+            "w"
+        ) as review_file:
+            json.dump(
+                {
+                    "body": "clang-tidy found no lines added",
+                    "event": "COMMENT",
+                    "comments": [],
+                },
+                review_file,
+            )
         return None
 
     print(f"Line filter for clang-tidy:\n{line_ranges}\n")

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -8,6 +8,7 @@
 import argparse
 import pathlib
 import pprint
+import sys
 
 from clang_tidy_review import (
     REVIEW_FILE,
@@ -111,4 +112,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -105,7 +105,7 @@ def main() -> int:
             pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
         )
 
-    return exit_code if args.num_comments_as_exitcode else 0
+    return (exit_code or 0) if args.num_comments_as_exitcode else 0
 
 
 if __name__ == "__main__":

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -105,10 +105,7 @@ def main() -> int:
             pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
         )
 
-    if args.num_comments_as_exitcode:
-        return exit_code
-    else:
-        return 0
+    return exit_code if args.num_comments_as_exitcode else 0
 
 
 if __name__ == "__main__":

--- a/post/clang_tidy_review/clang_tidy_review/post.py
+++ b/post/clang_tidy_review/clang_tidy_review/post.py
@@ -10,17 +10,17 @@ import pathlib
 import pprint
 
 from clang_tidy_review import (
-    PullRequest,
-    load_and_merge_reviews,
-    post_review,
-    load_metadata,
-    strip_enclosing_quotes,
-    download_artifacts,
-    post_annotations,
-    bool_argument,
     REVIEW_FILE,
+    PullRequest,
     add_auth_arguments,
+    bool_argument,
+    download_artifacts,
     get_auth_from_arguments,
+    load_and_merge_reviews,
+    load_metadata,
+    post_annotations,
+    post_review,
+    strip_enclosing_quotes,
 )
 
 

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -13,19 +13,18 @@ import subprocess
 
 from clang_tidy_review import (
     PullRequest,
+    add_auth_arguments,
+    bool_argument,
     create_review,
     fix_absolute_paths,
+    get_auth_from_arguments,
     message_group,
+    post_annotations,
     post_review,
     save_metadata,
-    strip_enclosing_quotes,
-    post_annotations,
-    bool_argument,
     set_output,
-    add_auth_arguments,
-    get_auth_from_arguments,
+    strip_enclosing_quotes,
 )
-
 
 BAD_CHARS_APT_PACKAGES_PATTERN = "[;&|($]"
 

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -6,10 +6,9 @@
 # See LICENSE for more information
 
 import argparse
-import os
-import pathlib
 import re
 import subprocess
+from pathlib import Path
 
 from clang_tidy_review import (
     PullRequest,
@@ -39,7 +38,7 @@ def main():
         "--clang_tidy_binary",
         help="clang-tidy binary",
         default="clang-tidy-14",
-        type=pathlib.Path,
+        type=Path,
     )
     parser.add_argument(
         "--build_dir", help="Directory with compile_commands.json", default="."
@@ -145,7 +144,7 @@ def main():
         with message_group(f"Running cmake: {cmake_command}"):
             subprocess.run(cmake_command, shell=True, check=True)
 
-    elif os.path.exists(build_compile_commands):
+    elif Path(build_compile_commands).exists():
         fix_absolute_paths(build_compile_commands, args.base_dir)
 
     pull_request = PullRequest(args.repo, args.pr, get_auth_from_arguments(args))

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -131,7 +131,7 @@ def main():
         with message_group(f"Installing additional packages: {apt_packages}"):
             subprocess.run(["apt-get", "update"], check=True)
             subprocess.run(
-                ["apt-get", "install", "-y", "--no-install-recommends"] + apt_packages,
+                ["apt-get", "install", "-y", "--no-install-recommends", *apt_packages],
                 check=True,
             )
 

--- a/post/clang_tidy_review/clang_tidy_review/review.py
+++ b/post/clang_tidy_review/clang_tidy_review/review.py
@@ -164,7 +164,7 @@ def main():
 
     if args.split_workflow:
         total_comments = 0 if review is None else len(review["comments"])
-        set_output("total_comments", total_comments)
+        set_output("total_comments", str(total_comments))
         print("split_workflow is enabled, not posting review")
         return
 

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [{name = "Peter Hill", email = "peter.hill@york.ac.uk"}]
 license = {text = "MIT"}
 dependencies = [
-    "PyGithub ~= 2.1",
+    "PyGithub ~= 2.6",
     "unidiff ~= 0.6.0",
     "pyyaml ~= 6.0.1",
     "urllib3 ~= 2.2.1",

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -52,13 +52,8 @@ extend_exclude = "_version.py"
 extend-select = [
   "B",           # flake8-bugbear
   "I",           # isort
-  "ARG",         # flake8-unused-arguments
   "C4",          # flake8-comprehensions
   "ICN",         # flake8-import-conventions
-  "G",           # flake8-logging-format
-  "PGH",         # pygrep-hooks
-  "PIE",         # flake8-pie
-  "PL",          # pylint
   "PT",          # flake8-pytest-style
   "PTH",         # flake8-use-pathlib
   "RET",         # flake8-return
@@ -67,18 +62,5 @@ extend-select = [
   "UP",          # pyupgrade
   "YTT",         # flake8-2020
   "EXE",         # flake8-executable
-  "NPY",         # NumPy specific rules
-  "PD",          # pandas-vet
   "FURB",        # refurb
-]
-ignore = [
-  "PLR2004",     # magic-comparison
-  "B9",          # flake8-bugbear opinionated warnings
-  "PLC0414",     # useless-import-alias
-  "PLR0913",     # too-many-arguments
-  "PLR0917",     # too-many-positional
-  "PLR0914",     # too-many-locals
-  "PLR0915",     # too-many-statements
-  "PLR0912",     # too-many-branches
-  "PTH123",      # builtin-open
 ]

--- a/post/clang_tidy_review/pyproject.toml
+++ b/post/clang_tidy_review/pyproject.toml
@@ -33,6 +33,10 @@ post = "clang_tidy_review.post:main"
 tests = [
     "pytest >= 3.3.0",
 ]
+lint = [
+  "black",
+  "ruff",
+]
 
 [tool.setuptools]
 packages = ["clang_tidy_review"]
@@ -40,3 +44,41 @@ packages = ["clang_tidy_review"]
 [tool.setuptools_scm]
 root = "../.."
 fallback_version = "0.0.0-dev"
+
+[tool.black]
+extend_exclude = "_version.py"
+
+[tool.ruff.lint]
+extend-select = [
+  "B",           # flake8-bugbear
+  "I",           # isort
+  "ARG",         # flake8-unused-arguments
+  "C4",          # flake8-comprehensions
+  "ICN",         # flake8-import-conventions
+  "G",           # flake8-logging-format
+  "PGH",         # pygrep-hooks
+  "PIE",         # flake8-pie
+  "PL",          # pylint
+  "PT",          # flake8-pytest-style
+  "PTH",         # flake8-use-pathlib
+  "RET",         # flake8-return
+  "RUF",         # Ruff-specific
+  "SIM",         # flake8-simplify
+  "UP",          # pyupgrade
+  "YTT",         # flake8-2020
+  "EXE",         # flake8-executable
+  "NPY",         # NumPy specific rules
+  "PD",          # pandas-vet
+  "FURB",        # refurb
+]
+ignore = [
+  "PLR2004",     # magic-comparison
+  "B9",          # flake8-bugbear opinionated warnings
+  "PLC0414",     # useless-import-alias
+  "PLR0913",     # too-many-arguments
+  "PLR0917",     # too-many-positional
+  "PLR0914",     # too-many-locals
+  "PLR0915",     # too-many-statements
+  "PLR0912",     # too-many-branches
+  "PTH123",      # builtin-open
+]

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -465,7 +465,7 @@ def test_decorate_comment_body():
 
 
 def test_timing_summary(monkeypatch):
-    monkeypatch.setattr(ctr, "PROFILE_DIR", str(TEST_DIR / f"src/clang-tidy-profile"))
+    monkeypatch.setattr(ctr, "PROFILE_DIR", str(TEST_DIR / "src/clang-tidy-profile"))
     profiling = ctr.load_and_merge_profiling()
     assert "time.clang-tidy.total.wall" in profiling["hello.cxx"].keys()
     assert "time.clang-tidy.total.user" in profiling["hello.cxx"].keys()

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -238,9 +238,7 @@ def test_line_ranges():
 
 
 def test_load_clang_tidy_warnings():
-    warnings = ctr.load_clang_tidy_warnings(
-        str(TEST_DIR / f"src/test_{ctr.FIXES_FILE}")
-    )
+    warnings = ctr.load_clang_tidy_warnings(TEST_DIR / f"src/test_{ctr.FIXES_FILE}")
 
     assert sorted(list(warnings.keys())) == ["Diagnostics", "MainSourceFile"]
     assert warnings["MainSourceFile"] == "/clang_tidy_review/src/hello.cxx"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -11,6 +11,8 @@ import unidiff
 
 import pytest
 
+from pathlib import Path
+
 TEST_DIR = pathlib.Path(__file__).parent
 TEST_FILE = TEST_DIR / "src/hello.cxx"
 TEST_DIFF = [
@@ -191,7 +193,7 @@ def test_fix_absolute_paths(tmp_path):
 
 
 def test_save_load_metadata(tmp_path, monkeypatch):
-    monkeypatch.setattr(ctr, "METADATA_FILE", str(tmp_path / ctr.METADATA_FILE))
+    monkeypatch.setattr(ctr, "METADATA_FILE", tmp_path / ctr.METADATA_FILE)
 
     ctr.save_metadata(42)
     meta = ctr.load_metadata()
@@ -391,7 +393,7 @@ def test_version(monkeypatch):
         lambda *args, **kwargs: MockClangTidyVersionProcess(expected_version),
     )
 
-    version = ctr.clang_tidy_version("not-clang-tidy")
+    version = ctr.clang_tidy_version(Path("not-clang-tidy"))
     assert version == expected_version
 
 
@@ -406,25 +408,27 @@ def test_config_file(monkeypatch, tmp_path):
 
     # If you set clang_tidy_checks to something and config_file to something, config_file is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="readability", config_file=str(config_file)
+        Path("not-clang-tidy"),
+        clang_tidy_checks="readability",
+        config_file=str(config_file),
     )
     assert flag == f"--config-file={config_file}"
 
     # If you set clang_tidy_checks and config_file to an empty string, neither are sent to the clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="", config_file=""
+        Path("not-clang-tidy"), clang_tidy_checks="", config_file=""
     )
     assert flag is None
 
     # If you get config_file to something, config_file is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="", config_file=str(config_file)
+        Path("not-clang-tidy"), clang_tidy_checks="", config_file=str(config_file)
     )
     assert flag == f"--config-file={config_file}"
 
     # If you get clang_tidy_checks to something and config_file to nothing, clang_tidy_checks is sent to clang-tidy.
     flag = ctr.config_file_or_checks(
-        "not-clang-tidy", clang_tidy_checks="readability", config_file=""
+        Path("not-clang-tidy"), clang_tidy_checks="readability", config_file=""
     )
     assert flag == "--checks=readability"
 
@@ -465,7 +469,7 @@ def test_decorate_comment_body():
 
 
 def test_timing_summary(monkeypatch):
-    monkeypatch.setattr(ctr, "PROFILE_DIR", str(TEST_DIR / "src/clang-tidy-profile"))
+    monkeypatch.setattr(ctr, "PROFILE_DIR", TEST_DIR / "src/clang-tidy-profile")
     profiling = ctr.load_and_merge_profiling()
     assert "time.clang-tidy.total.wall" in profiling["hello.cxx"].keys()
     assert "time.clang-tidy.total.user" in profiling["hello.cxx"].keys()


### PR DESCRIPTION
Our pipelines that are using this forked action are failing with the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/post", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/local/lib/python3.13/site-packages/clang_tidy_review/post.py", line 103, in main
    exit_code = post_review(
        pull_request, review, args.max_comments, lgtm_comment_body, args.dry_run
    )
  File "/usr/local/lib/python3.13/site-packages/clang_tidy_review/__init__.py", line 1347, in post_review
    pull_request.post_lgtm_comment(lgtm_comment_body)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/clang_tidy_review/__init__.py", line 373, in post_lgtm_comment
    for comment in comments:
                   ^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/github/PaginatedList.py", line 84, in __iter__
    newElements = self._grow()
  File "/usr/local/lib/python3.13/site-packages/github/PaginatedList.py", line 95, in _grow
    newElements = self._fetchNextPage()
  File "/usr/local/lib/python3.13/site-packages/github/PaginatedList.py", line 3[24](https://github.com/The-OpenROAD-Project/OpenROAD/actions/runs/13801194073/job/38603792944#step:5:25), in _fetchNextPage
    return self._getPage(data, headers)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/github/PaginatedList.py", line 357, in _getPage
    self.__contentClass(self.__requester, headers, self._transformAttributes(element))  # type: ignore
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PullRequest.get_pr_comments.<locals>.get_element() missing 1 required positional argument: 'completed'
```

Example: https://github.com/The-OpenROAD-Project/OpenROAD/actions/runs/13801194073/job/38603792944

Currently there's an [issue](https://github.com/ZedThree/clang-tidy-review/issues/144) opened in the original repo and a [PR](https://github.com/ZedThree/clang-tidy-review/pull/142) that addresses the issue but has not been merged just yet into the original repo.

This PR syncs with [upstream](https://github.com/ZedThree/clang-tidy-review/tree/master) and applies the bugfix from [Nerixyz/fix/pr-comments](https://github.com/Nerixyz/clang-tidy-review/tree/fix/pr-comments)