### PR TITLE
Support for clang-tidy-19 and set the default version to 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt update && \
     apt-get install -y --no-install-recommends\
     build-essential cmake git \
     tzdata \
-    clang-tidy-14 \
     clang-tidy-15 \
+    clang-tidy-19 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     require: false
   clang_tidy_version:
     description: 'Version of clang-tidy to use; one of 14, 15, 16, 17, 18, 19'
-    default: '19'
+    default: '15'
     required: false
   clang_tidy_checks:
     description: 'List of checks'


### PR DESCRIPTION
- Removed `clang-tidy-14` and added `clang-tidy-19`
- Set the default version to 15