### PR TITLE
gha: use commit sha instead of version/tag

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,9 +13,9 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
       with:
         python-version: 3.x
     - name: Install black
@@ -29,6 +29,6 @@ jobs:
     - name: Run black
       run: |
         black .
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a  # v4.16.0
       with:
         commit_message: "Apply black changes"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
Using commit sha helps prevent chain attacks that have become common.